### PR TITLE
 Load portal details when clicking map link

### DIFF
--- a/portals_gallery_script.js
+++ b/portals_gallery_script.js
@@ -4,7 +4,7 @@
 // @description    Creates the gallery of portals that can be used to solve the First Saturday passcode.
 // @author         Kofirs2634 aka Nerotu
 // @category       Info
-// @version        1.1
+// @version        1.0
 // @match          https://intel.ingress.com/*
 // @grant          none
 
@@ -45,7 +45,7 @@ window.plugin.portalsGallery.open = () => {
     dialog({
         html: '<div id="gallery-cnt"></div>',
         title: 'Portals Gallery',
-        width: 'auto'
+        width: '1600px'
     });
     $('#gallery-cnt')
         .append($('<div>', { class: 'controls' })
@@ -95,13 +95,13 @@ function makeTable(array) {
     if (self.sortmode == 't') array = byTitle(array)
     else if (self.sortmode == 'd') array = byDistance(array)
 
-    var rows = Math.ceil(array.length / 3);
+    var rows = Math.ceil(array.length / 6);
     if (array.length) $('.results').text(`The gallery shows ${array.length} portals`)
     else $('.results').text('There\'re no portals in the gallery')
     for (var i = 0; i < rows; i++) {
         $('#gallery').append($('<div>', { class: 'gallery-row', id: `gallery-row-${i}` }))
-        for (var j = 0; j < 3; j++) {
-            var p = array[i * 3 + j];
+        for (var j = 0; j < 6; j++) {
+            var p = array[i * 6 + j];
             if (!p) return;
             const latlng = getCoords(p);
             const renderPortalLink = document.createElement('a');
@@ -111,7 +111,7 @@ function makeTable(array) {
                 window.renderPortalDetails(guid);
             });
             $(`#gallery-row-${i}`).append($('<div>')
-                .append($('<img>', { src: p.u, width: 200, class: 'gallery-img' }))
+                .append($('<img>', { src: p.u, width: 250, class: 'gallery-img' }))
                 .append($('<span>', { class: 'gallery-coords', text: getCoords(p) }))
                 .append(renderPortalLink)
             )

--- a/portals_gallery_script.js
+++ b/portals_gallery_script.js
@@ -4,11 +4,8 @@
 // @description    Creates the gallery of portals that can be used to solve the First Saturday passcode.
 // @author         Kofirs2634 aka Nerotu
 // @category       Info
-// @version        1.0
-// @include        https://intel.ingress.com/
-// @include        http://intel.ingress.com/
-// @match          https://intel.ingress.com/
-// @match          http://intel.ingress.com/
+// @version        1.1
+// @match          https://intel.ingress.com/*
 // @grant          none
 
 // @downloadURL https://github.com/Kofirs2634/IITC-Portals-Gallery/raw/main/portals_gallery_script.js
@@ -34,7 +31,7 @@ window.plugin.portalsGallery.collect = () => {
     self.storage = [];
     for (var i in window.portals) {
         var path = portals[i].options.data;
-        if (path.title && path.image) self.storage.push({ n: path.title, p: { lt: path.latE6 / 1e6, ln: path.lngE6 / 1e6 }, u: path.image })
+        if (path.title && path.image) self.storage.push({ n: path.title, p: { lt: path.latE6 / 1e6, ln: path.lngE6 / 1e6 }, u: path.image, g: portals[i].options.guid })
     }
 }
 
@@ -91,6 +88,7 @@ window.plugin.portalsGallery.doSearch = (array) => {
  * @param {object[]} array An array of rendered portals - `window.plugin.portalsGallery.storage`
  */
 function makeTable(array) {
+  
     var self = window.plugin.portalsGallery;
     $('#gallery').empty();
 
@@ -105,10 +103,17 @@ function makeTable(array) {
         for (var j = 0; j < 3; j++) {
             var p = array[i * 3 + j];
             if (!p) return;
+            const latlng = getCoords(p);
+            const renderPortalLink = document.createElement('a');
+            const guid = p.g;
+            renderPortalLink.textContent = `${p.n}`;
+            renderPortalLink.addEventListener('click', function(e) {
+                window.renderPortalDetails(guid);
+            });
             $(`#gallery-row-${i}`).append($('<div>')
                 .append($('<img>', { src: p.u, width: 200, class: 'gallery-img' }))
                 .append($('<span>', { class: 'gallery-coords', text: getCoords(p) }))
-                .append($('<a>', { class: 'gallery-link', href: `https://intel.ingress.com/intel?ll=${getCoords(p)}&z=17&pll=${getCoords(p)}`, text: p.n }))
+                .append(renderPortalLink)
             )
         }
     }
@@ -175,7 +180,7 @@ function appendStyles() {
             'align-items: baseline;' +
             'margin-bottom: 25px;' +
             '} .gallery-row > div {' +
-            'max-width: 250px;' +
+            'max-width: 500px;' +
             'display: flex;' +
             'flex-direction: column;' +
             'align-items: center;' +

--- a/portals_gallery_script.js
+++ b/portals_gallery_script.js
@@ -4,7 +4,7 @@
 // @description    Creates the gallery of portals that can be used to solve the First Saturday passcode.
 // @author         Kofirs2634 aka Nerotu
 // @category       Info
-// @version        1.1
+// @version        1.2
 // @match          https://intel.ingress.com/*
 // @grant          none
 
@@ -21,7 +21,7 @@ if(typeof window.plugin !== 'function') window.plugin = function() {};
 window.plugin.portalsGallery = () => {};
 window.plugin.portalsGallery.storage = [];
 window.plugin.portalsGallery.sortmode = 't';
-
+window.plugin.portalsGallery.imagesPerRow = 3;
 /**
  * Collects the data of rendered portals
  * @public
@@ -41,23 +41,51 @@ window.plugin.portalsGallery.collect = () => {
  */
 window.plugin.portalsGallery.open = () => {
     var self = window.plugin.portalsGallery;
+
+    if ('iitc_gallery_row_length' in localStorage) {
+        let rowLength = localStorage['iitc_gallery_row_length']
+        if (rowLength === undefined || rowLength === 'undefined' || rowLength === null || rowLength === "null" || rowLength === ""){
+            rowLength = 3;
+            localStorage['iitc_gallery_row_length'] = rowLength;
+        }
+        window.plugin.portalsGallery.imagesPerRow = localStorage['iitc_gallery_row_length'];
+    } else {
+        console.log("not found in local storage")
+        localStorage['iitc_gallery_row_length'] = window.plugin.portalsGallery.imagesPerRow;
+    }
+
     self.collect();
+    const width = (self.imagesPerRow * 250) + 150;
     dialog({
         html: '<div id="gallery-cnt"></div>',
         title: 'Portals Gallery',
-        width: 'auto'
+        dialogClass: 'gallery-dialog',
+        width: width,
+        position: { my: 'left top', at: 'left+50 top+50'}
     });
     $('#gallery-cnt')
-        .append($('<div>', { class: 'controls' })
+        .append($('<div>', { id: 'gallery-cnt-div', class: 'controls' })
             .append($('<label>', { text: 'Search query: ' }).append($('<input>', { type: 'search', id: 'gallery-search' })))
             .append($('<label>', { text: 'Sort by: ' }).append($('<select>', { id: 'gallery-sort' })
                 .append($('<option>', { value: 't', text: 'title' }))
                 .append($('<option>', { value: 'd', text: 'distance' }))
             ))
             .append($('<label>', { class: 'sort-distance', text: 'Distance relative ' }).append($('<input>', { id: 'sort-coords', type: 'search', placeholder: 'latitiude,longitude' })))
+            .append($('<label>', { text: 'Images per row: ' }).append($('<select>', { id: 'row-length' })
+            ))
         )
         .append($('<div>', { class: 'results' }))
         .append($('<div>', { id: 'gallery' }));
+
+    for (let i = 3; i < 9; i++) {
+        let option;
+        if (i == self.imagesPerRow) {
+            option = `<option selected=selected>${i}</option>`
+        } else {
+            option = `<option>${i}</option>`
+        }
+        $('#row-length').append(option);
+    }
 
     makeTable(self.storage);
 
@@ -65,7 +93,13 @@ window.plugin.portalsGallery.open = () => {
     $('#sort-coords').bind('input paste', () => makeTable(self.storage))
     $('#gallery-sort').bind('change', e => {
         self.sortmode = $(e.target).val();
-        makeTable(self.storage)
+        makeTable(self.storage);
+    })
+    $('#row-length').bind('change', e => {
+        self.imagesPerRow = $(e.target).val();
+        makeTable(self.storage);
+        $('#gallery-cnt')[0].parentElement.parentElement.style["width"] = `${(self.imagesPerRow * 250) + 150}px`;
+        localStorage['iitc_gallery_row_length'] = self.imagesPerRow;
     })
 }
 
@@ -94,13 +128,13 @@ function makeTable(array) {
     if (self.sortmode == 't') array = byTitle(array)
     else if (self.sortmode == 'd') array = byDistance(array)
 
-    var rows = Math.ceil(array.length / 3);
+    var rows = Math.ceil(array.length / self.imagesPerRow);
     if (array.length) $('.results').text(`The gallery shows ${array.length} portals`)
     else $('.results').text('There\'re no portals in the gallery')
     for (var i = 0; i < rows; i++) {
         $('#gallery').append($('<div>', { class: 'gallery-row', id: `gallery-row-${i}` }))
-        for (var j = 0; j < 3; j++) {
-            var p = array[i * 3 + j];
+        for (var j = 0; j < self.imagesPerRow; j++) {
+            var p = array[i * self.imagesPerRow + j];
             if (!p) return;
             const renderPortalLink = document.createElement('a');
             const guid = p.g;
@@ -109,7 +143,7 @@ function makeTable(array) {
                 window.renderPortalDetails(guid);
             });
             $(`#gallery-row-${i}`).append($('<div>')
-                .append($('<img>', { src: p.u, width: 200, class: 'gallery-img' }))
+                .append($('<img>', { src: p.u, width: 250, class: 'gallery-img' }))
                 .append($('<span>', { class: 'gallery-coords', text: getCoords(p) }))
                 .append(renderPortalLink)
             )
@@ -188,7 +222,8 @@ function appendStyles() {
             '} .gallery-link {' +
             'display: block;' +
             'text-align: center;' +
-            '} .sort-distance { display: block }'
+            '} .sort-distance { display: block }' +
+            '.gallery-dialog {max-width: 80%;}'
     }))
 }
 

--- a/portals_gallery_script.js
+++ b/portals_gallery_script.js
@@ -4,7 +4,7 @@
 // @description    Creates the gallery of portals that can be used to solve the First Saturday passcode.
 // @author         Kofirs2634 aka Nerotu
 // @category       Info
-// @version        1.0
+// @version        1.1
 // @match          https://intel.ingress.com/*
 // @grant          none
 
@@ -45,7 +45,7 @@ window.plugin.portalsGallery.open = () => {
     dialog({
         html: '<div id="gallery-cnt"></div>',
         title: 'Portals Gallery',
-        width: '1600px'
+        width: 'auto'
     });
     $('#gallery-cnt')
         .append($('<div>', { class: 'controls' })
@@ -88,22 +88,20 @@ window.plugin.portalsGallery.doSearch = (array) => {
  * @param {object[]} array An array of rendered portals - `window.plugin.portalsGallery.storage`
  */
 function makeTable(array) {
-  
     var self = window.plugin.portalsGallery;
     $('#gallery').empty();
 
     if (self.sortmode == 't') array = byTitle(array)
     else if (self.sortmode == 'd') array = byDistance(array)
 
-    var rows = Math.ceil(array.length / 6);
+    var rows = Math.ceil(array.length / 3);
     if (array.length) $('.results').text(`The gallery shows ${array.length} portals`)
     else $('.results').text('There\'re no portals in the gallery')
     for (var i = 0; i < rows; i++) {
         $('#gallery').append($('<div>', { class: 'gallery-row', id: `gallery-row-${i}` }))
-        for (var j = 0; j < 6; j++) {
-            var p = array[i * 6 + j];
+        for (var j = 0; j < 3; j++) {
+            var p = array[i * 3 + j];
             if (!p) return;
-            const latlng = getCoords(p);
             const renderPortalLink = document.createElement('a');
             const guid = p.g;
             renderPortalLink.textContent = `${p.n}`;
@@ -111,7 +109,7 @@ function makeTable(array) {
                 window.renderPortalDetails(guid);
             });
             $(`#gallery-row-${i}`).append($('<div>')
-                .append($('<img>', { src: p.u, width: 250, class: 'gallery-img' }))
+                .append($('<img>', { src: p.u, width: 200, class: 'gallery-img' }))
                 .append($('<span>', { class: 'gallery-coords', text: getCoords(p) }))
                 .append(renderPortalLink)
             )

--- a/portals_gallery_script.js
+++ b/portals_gallery_script.js
@@ -178,7 +178,7 @@ function appendStyles() {
             'align-items: baseline;' +
             'margin-bottom: 25px;' +
             '} .gallery-row > div {' +
-            'max-width: 500px;' +
+            'max-width: 250px;' +
             'display: flex;' +
             'flex-direction: column;' +
             'align-items: center;' +


### PR DESCRIPTION
 Load portal details when clicking map link

Previously clicking the map link for an item in the gallery would simply follow the href to that portal's permalink. With this change clicking on the link will instead render the portal details.